### PR TITLE
Enable pf tests

### DIFF
--- a/scripts/build/build-test_image.sh
+++ b/scripts/build/build-test_image.sh
@@ -41,7 +41,7 @@ done
 
 sudo cp /etc/resolv.conf ufs/etc/
 sudo chroot ufs env ASSUME_ALWAYS_YES=yes pkg update
-sudo chroot ufs pkg install -y kyua perl5
+sudo chroot ufs pkg install -y kyua perl5 scapy
 
 cat <<EOF | sudo tee ufs/etc/fstab
 # Device        Mountpoint      FStype  Options Dump    Pass#
@@ -54,6 +54,7 @@ cat <<EOF | sudo tee ufs/etc/rc.local
 #!/bin/sh -ex
 PATH=/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin:/usr/local/bin
 export PATH
+kldload pf
 echo
 echo "--------------------------------------------------------------"
 echo "start kyua tests!"


### PR DESCRIPTION
Now that VIMAGE is enabled we can execute the pf tests. This also
requires scapy (to generate packets) to be installed, and the pf module
to be loaded.