### PR TITLE
Read-only src build

### DIFF
--- a/scripts/build/build-world-kernel-head.sh
+++ b/scripts/build/build-world-kernel-head.sh
@@ -8,7 +8,13 @@ rm -fr ${MAKEOBJDIRPREFIX}
 MAKECONF=${MAKECONF:-/dev/null}
 SRCCONF=${SRCCONF:-/dev/null}
 
-cd /usr/src
+# Mount source readonly
+mkdir -p /usr/src.ro
+mount -o ro -t nullfs /usr/src /usr/src.ro
+# Set cleanup trap
+trap "umount /usr/src.ro" exit
+
+cd /usr/src.ro
 
 sudo make -j ${JFLAG} -DNO_CLEAN \
 	buildworld \

--- a/scripts/build/build-world-kernel-head.sh
+++ b/scripts/build/build-world-kernel-head.sh
@@ -23,8 +23,9 @@ sudo make -j ${JFLAG} -DNO_CLEAN \
 	__MAKE_CONF=${MAKECONF} \
 	SRCCONF=${SRCCONF}
 
-cd /usr/src/release
+cd release
 
+_RELOBJDIR=$(make -V .OBJDIR)
 sudo make clean
 sudo make -DNOPORTS -DNOSRC -DNODOC packagesystem \
 	TARGET=${TARGET} TARGET_ARCH=${TARGET_ARCH} \
@@ -32,7 +33,7 @@ sudo make -DNOPORTS -DNOSRC -DNODOC packagesystem \
 
 ARTIFACT_DEST=artifact/${FBSD_BRANCH}/r${SVN_REVISION}/${TARGET}/${TARGET_ARCH}
 sudo mkdir -p ${ARTIFACT_DEST}
-sudo mv /usr/obj/usr/src/${TARGET}.${TARGET_ARCH}/release/*.txz ${ARTIFACT_DEST}
-sudo mv /usr/obj/usr/src/${TARGET}.${TARGET_ARCH}/release/MANIFEST ${ARTIFACT_DEST}
+sudo mv ${_RELOBJDIR}/*.txz ${ARTIFACT_DEST}
+sudo mv ${_RELOBJDIR}/MANIFEST ${ARTIFACT_DEST}
 
 echo "SVN_REVISION=${SVN_REVISION}" > ${WORKSPACE}/trigger.property

--- a/scripts/build/build-world-kernel.sh
+++ b/scripts/build/build-world-kernel.sh
@@ -23,8 +23,8 @@ sudo make -j ${JFLAG} -DNO_CLEAN \
 	__MAKE_CONF=${MAKECONF} \
 	SRCCONF=${SRCCONF}
 
-cd /usr/src/release
-
+cd release
+# Do note that release scripts on stable/11 are *not* RO-friendly
 sudo make clean
 sudo make -DNOPORTS -DNOSRC -DNODOC packagesystem \
 	TARGET=${TARGET} TARGET_ARCH=${TARGET_ARCH} \


### PR DESCRIPTION
(This is completely untested)

Mount src tree read-only for building to make sure we don't break it, given that it is a supported configuration according to build(7) [1]. It should be OK for all -head builds. Other branches will need a little more work since the release scripts are not RO-safe.

[1] https://www.freebsd.org/cgi/man.cgi?build(7)