### PR TITLE
Enable zfs tests

### DIFF
--- a/scripts/build/build-test_image.sh
+++ b/scripts/build/build-test_image.sh
@@ -41,7 +41,7 @@ done
 
 sudo cp /etc/resolv.conf ufs/etc/
 sudo chroot ufs env ASSUME_ALWAYS_YES=yes pkg update
-sudo chroot ufs pkg install -y kyua perl5 scapy
+sudo chroot ufs pkg install -y kyua perl5 scapy ksh93
 
 cat <<EOF | sudo tee ufs/etc/fstab
 # Device        Mountpoint      FStype  Options Dump    Pass#


### PR DESCRIPTION
Many of the ZFS tests require ksh93. Install the package, for two reasons:

1) This enables the execution of more tests
2) kyua has an issue, which causes it to not skip these tests if ksh93 is not installed but instead report them as failed. See https://github.com/jmmv/kyua/issues/177

Installing ksh93 works around this problem, and will reduce the number of false positive test failures.