### PR TITLE
FreeBSD-stable-10-i386-testvm WITH_TESTS=1

### DIFF
--- a/jobs/FreeBSD-stable-10-i386-testvm/build.sh
+++ b/jobs/FreeBSD-stable-10-i386-testvm/build.sh
@@ -7,5 +7,5 @@ env \
 	WITH_LIB32=0 \
 	WITH_DEBUG=0 \
 	WITH_DOC=1 \
-	WITH_TESTS=0 \
+	WITH_TESTS=1 \
 	sh -x freebsd-ci/scripts/build/build-test_image.sh


### PR DESCRIPTION
The FreeBSD-stable-10-i386-test job uses an image from
FreeBSD-stable-10-i386-testvm and tries to run the tests in /usr/tests.
Build/install those tests, like we do for the other testvms.