### PR TITLE
Set kern.cryptodevallowsoft=1

### DIFF
--- a/scripts/build/build-test_image.sh
+++ b/scripts/build/build-test_image.sh
@@ -103,6 +103,7 @@ shutdown -p now
 EOF
 
 cat <<EOF | sudo tee ufs/etc/sysctl.conf
+kern.cryptodevallowsoft=1
 net.add_addr_allfibs=0
 vfs.aio.enable_unsafe=1
 EOF


### PR DESCRIPTION
It's required for tests/sys/opencrypto/blake2_test

PR:	230671