### PR TITLE
Load pfsync module

### DIFF
--- a/scripts/build/config/testvm/append/etc/rc.conf
+++ b/scripts/build/config/testvm/append/etc/rc.conf
@@ -4,8 +4,8 @@
 # mac_bsdextended:	sys/mac/bsdextended
 # mac_portacl:		sys/mac/portacl
 # mqueuefs:		sys/kern/mqueue_test
-# pf:			sys/netpfil/pf
-kld_list="blake2 cryptodev mac_bsdextended mac_portacl mqueuefs pf"
+# pf / pfsync:	    sys/netpfil/pf
+kld_list="blake2 cryptodev mac_bsdextended mac_portacl mqueuefs pfsync"
 auditd_enable="YES"
 background_fsck="NO"
 sendmail_enable="NONE"


### PR DESCRIPTION
The system tests now include a pfsync test, so we want to load the
pfsync module. This automatically loads the pf module as well, so we can
replace it, rather than add it.