### PR TITLE
Inject /boot/entropy in VM images built for CI

### DIFF
--- a/jobs/FreeBSD-head-aarch64-images/build.sh
+++ b/jobs/FreeBSD-head-aarch64-images/build.sh
@@ -30,6 +30,7 @@ cat <<EOF | sudo tee ufs/etc/fstab
 /dev/gpt/rootfs /               ufs     rw      1       1
 EOF
 
+sudo dd if=/dev/random of=ufs/boot/entropy bs=4k count=1
 sudo makefs -d 6144 -t ffs -s 16g -o version=2,bsize=32768,fsize=4096 ufs.img ufs
 mkimg -s gpt -f raw \
 	-b ufs/boot/pmbr \

--- a/jobs/FreeBSD-head-aarch64-testvm/build.sh
+++ b/jobs/FreeBSD-head-aarch64-testvm/build.sh
@@ -52,6 +52,7 @@ EOF
 
 sudo rm -f ufs/etc/resolv.conf
 
+sudo dd if=/dev/random of=ufs/boot/entropy bs=4k count=1
 sudo makefs -d 6144 -t ffs -f 200000 -s 2g -o version=2,bsize=32768,fsize=4096 ufs.img ufs
 mkimg -s gpt -f raw \
 	-b ufs/boot/pmbr \

--- a/jobs/FreeBSD-head-riscv64-build/basic.files
+++ b/jobs/FreeBSD-head-riscv64-build/basic.files
@@ -20,6 +20,7 @@ bin/sh
 bin/sleep
 bin/stty
 bin/tcsh
+boot/entropy
 dev
 etc/defaults/rc.conf
 etc/devd.conf

--- a/jobs/FreeBSD-head-riscv64-build/build.sh
+++ b/jobs/FreeBSD-head-riscv64-build/build.sh
@@ -42,6 +42,7 @@ make CROSS_TOOLCHAIN=riscv64-gcc \
 	distribution
 
 cd ${WORKSPACE}
+dd if=/dev/random of=${DESTDIR}/boot/entropy bs=4k count=1
 src/tools/tools/makeroot/makeroot.sh -s 32m -f ${JOB_BASE}/basic.files ${IMAGE_NAME} ${DESTDIR}
 
 cd ${WORKSPACE}/src


### PR DESCRIPTION
Otherwise, random is unlikely to be available early without a fast random
source.

Reported by:	Gerald Aryeetey (GeraldNDA @ Github)