### PR TITLE
Require net/py-dpkt as part of the test image

### DIFF
--- a/scripts/build/build-test_image.sh
+++ b/scripts/build/build-test_image.sh
@@ -52,12 +52,14 @@ sudo chroot ufs env ASSUME_ALWAYS_YES=yes pkg update
 # nmap: sys/netinet/fibs_test:arpresolve_checks_interface_fib
 # perl5: lots of stuff
 # pkgconf: local/lutok/examples_test, local/atf/atf-c, local/atf/atf-c++
-# python2: sys/opencrypto
+# py-dpkt: sys/opencrypto/runtests
+# python2: sys/opencrypto/runtests
 sudo chroot ufs pkg install -y	\
 	devel/gdb		\
 	devel/kyua		\
 	lang/perl5.28		\
 	lang/python2		\
+	net/py-dpkt		\
 	net/scapy		\
 	security/nist-kat	\
 	security/nmap		\


### PR DESCRIPTION
In short, tests/sys/opencrypto/runtests has a copy of the dpkt.py module
checked in from the dpkt package, which is based on a 2014 snapshot of
the package. In order to make forward progress and eliminate the
duplicate copy of dpkt, the first logical step is to require the upstream
package instead of relying on a partial copy of the dpkt package.

PR:	237403

Signed-off-by: Enji Cooper <yaneurabeya@gmail.com>