### PR TITLE
Switch HEAD mips build jobs to using mips-gcc.

### DIFF
--- a/jobs/FreeBSD-head-mips-build/build.sh
+++ b/jobs/FreeBSD-head-mips-build/build.sh
@@ -5,6 +5,7 @@ SRCCONF=${WORKSPACE}/`dirname $0`/src.conf
 env \
 	JFLAG=${BUILDER_JFLAG} \
 	SRCCONF=${SRCCONF} \
+	CROSS_TOOLCHAIN=mips-gcc \
 	TARGET=mips \
 	TARGET_ARCH=mips \
 	sh -x ${WORKSPACE}/freebsd-ci/scripts/build/build-world-kernel-head.sh

--- a/jobs/FreeBSD-head-mips-build/pkg-list
+++ b/jobs/FreeBSD-head-mips-build/pkg-list
@@ -1,0 +1,1 @@
+mips-xtoolchain-gcc

--- a/jobs/FreeBSD-head-mips64-build/build.sh
+++ b/jobs/FreeBSD-head-mips64-build/build.sh
@@ -5,6 +5,7 @@ SRCCONF=${WORKSPACE}/`dirname $0`/src.conf
 env \
 	JFLAG=${BUILDER_JFLAG} \
 	SRCCONF=${SRCCONF} \
+	CROSS_TOOLCHAIN=mips-gcc \
 	TARGET=mips \
 	TARGET_ARCH=mips64 \
 	sh -x ${WORKSPACE}/freebsd-ci/scripts/build/build-world-kernel-head.sh

--- a/jobs/FreeBSD-head-mips64-build/pkg-list
+++ b/jobs/FreeBSD-head-mips64-build/pkg-list
@@ -1,0 +1,1 @@
+mips-xtoolchain-gcc


### PR DESCRIPTION
I haven't tested this (not sure how).  One issue I see is that stable-12 and head share the same config in freebsd-src.yaml and after this change the head jobs should use the 'gcc' warnscanner instead of 'gcc4'.  Not sure if the best way is to split out separate 'gcc4' projects that only build stable-12 perhaps and only leave 'head' in the existing jobs, or can you configure the warnscanner by branch somehow?