### PR TITLE
Don't add /usr/tests/sys/cddl/zfs/bin to PATH

### DIFF
--- a/jobs/FreeBSD-head-amd64-test_zfs/meta/run.sh
+++ b/jobs/FreeBSD-head-amd64-test_zfs/meta/run.sh
@@ -3,7 +3,6 @@
 METADIR=/meta
 
 PATH=/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin:/usr/local/bin
-PATH=${PATH}:/usr/tests/sys/cddl/zfs/bin
 export PATH
 
 cat <<EOF >> /usr/local/etc/kyua/kyua.conf


### PR DESCRIPTION
That directory is added to PATH once the tests start.  Before tests
start, it should not be part of the PATH, because it interferes with the
use of required_programs in certain test cases.

This should fix tests like tests.cli_root.zfs_share.zfs_share_test.zfs_share_001_pos that require Solaris-specific programs like svcs.