### PR TITLE
Add kill10 to the skipfile.

### DIFF
--- a/jobs/FreeBSD-head-amd64-test_ltp/meta/run.sh
+++ b/jobs/FreeBSD-head-amd64-test_ltp/meta/run.sh
@@ -24,8 +24,10 @@ utstest_unshare_4 utstest_unshare_4
 kill10 kill10
 END
 
+mdconfig -s 262144k
+
 set +e
-yes | limits -n 1024 chroot /compat/linux /opt/ltp/runltp -Q -S /ltp-skipfile.conf -pl /ltp-results.log
+yes | limits -n 1024 chroot /compat/linux /opt/ltp/runltp -Q -S /ltp-skipfile.conf -b /dev/md0 -pl /ltp-results.log
 echo $? > ${METADIR}/runltp.error
 set -e
 

--- a/jobs/FreeBSD-head-amd64-test_ltp/meta/run.sh
+++ b/jobs/FreeBSD-head-amd64-test_ltp/meta/run.sh
@@ -21,6 +21,7 @@ inotify06 inotify06
 pidns05 pidns05
 utstest_unshare_3 utstest_unshare_3
 utstest_unshare_4 utstest_unshare_4
+kill10 kill10
 END
 
 set +e


### PR DESCRIPTION
Otherwise it hangs sometimes; looks like this:

00:08:48.874 <<<test_start>>>
00:08:48.875 tag=kill10 stime=1577318798
00:08:48.875 cmdline="kill10"
00:08:48.876 contacts=""
00:08:48.876 analysis=exit
00:08:48.876 <<<test_output>>>
00:08:50.098 kill10      1  [1;31mTBROK[0m  :  kill10.c:666: received unexpected signal from 0
00:08:50.099 kill10      2  [1;31mTBROK[0m  :  kill10.c:666: Remaining cases broken
00:08:50.110 kill10      1  [1;31mTBROK[0m  :  kill10.c:666: received unexpected signal from 0
00:08:50.111 kill10      2  [1;31mTBROK[0m  :  kill10.c:666: Remaining cases broken
07:58:32.456 Dec 26 07:56:22  syslogd: exiting on signal 15