### PR TITLE
Build correct LINT configuration for powerpc64.

### DIFF
--- a/jobs/FreeBSD-head-powerpc64-LINT/build.sh
+++ b/jobs/FreeBSD-head-powerpc64-LINT/build.sh
@@ -4,4 +4,5 @@ env \
 	JFLAG=${BUILDER_JFLAG} \
 	TARGET=powerpc \
 	TARGET_ARCH=powerpc64 \
+	KERNCONF=LINT64 \
 	sh -x freebsd-ci/scripts/build/build-kernel-LINT.sh


### PR DESCRIPTION
The FreeBSD-head-powerpc64-LINT job needs to build LINT64, not the default LINT, to pick up the correct settings and avoid the build bailing with
```
ld: error: accf_data.o is incompatible with elf32ppc_fbsd
*** [accf_data.kld] Error code 1
```