### PR TITLE
On head, disable mac_bsdextended

### DIFF
--- a/scripts/build/config-head/testvm/append/etc/sysctl.conf
+++ b/scripts/build/config-head/testvm/append/etc/sysctl.conf
@@ -1,4 +1,5 @@
 kern.cryptodevallowsoft=1
 net.add_addr_allfibs=0
+security.mac.bsdextended.enabled=0
 vfs.aio.enable_unsafe=1
 vfs.usermount=1


### PR DESCRIPTION
As of SVN 360567, the mac_bsdextended tests will enable
mac_bsdextended(4) if it is loaded but disabled.  Disabling it from boot
allows the fusefs tests to run.

https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=244229