### PR TITLE
Revert 8ef9526fb9b1c5246b97868945b9071b7a382cc8

### DIFF
--- a/scripts/build/build-test_image-head.sh
+++ b/scripts/build/build-test_image-head.sh
@@ -74,6 +74,7 @@ if [ "${TARGET}" = "amd64" -o "${TARGET}" = "i386" ]; then
 		gdb		\
 		ksh93		\
 		kyua		\
+		nist-kat	\
 		nmap		\
 		perl5		\
 		py37-dpkt	\


### PR DESCRIPTION
This reenables nist-kat on head, because a package is now available