### PR TITLE
Override VM_CPU_COUNT and VM_MEM_SIZE.

### DIFF
--- a/jobs/FreeBSD-head-aarch64-test/build.sh
+++ b/jobs/FreeBSD-head-aarch64-test/build.sh
@@ -9,6 +9,9 @@ export QEMU_MACHINE="virt"
 #      This means we effectively pass root device twice.
 export QEMU_EXTRA_PARAM="-bios QEMU_EFI.fd -cpu cortex-a57 -drive if=virtio,file=disk-test.img,format=raw"
 
+# XXX: Temporary, to compare performance results.
+export VM_CPU_COUNT=1
+
 export USE_TEST_SUBR="
 disable-dtrace-tests.sh
 disable-zfs-tests.sh

--- a/jobs/FreeBSD-head-armv7-test/build.sh
+++ b/jobs/FreeBSD-head-armv7-test/build.sh
@@ -7,6 +7,12 @@ export QEMU_ARCH="arm"
 export QEMU_MACHINE="virt"
 export QEMU_EXTRA_PARAM="-bios /usr/local/share/u-boot/u-boot-qemu-arm/u-boot.bin"
 
+# U-Boot hangs with 4G.
+export VM_MEM_SIZE="3g"
+
+# XXX: Temporary, to compare performance results.
+export VM_CPU_COUNT=1
+
 export USE_TEST_SUBR="
 disable-dtrace-tests.sh
 disable-zfs-tests.sh

--- a/scripts/test/run-tests.sh
+++ b/scripts/test/run-tests.sh
@@ -18,8 +18,8 @@ TIMEOUT=$((${TIMEOUT_MS} / 1000))
 TIMEOUT_EXPECT=$((${TIMEOUT} - 60))
 TIMEOUT_VM=$((${TIMEOUT_EXPECT} - 120))
 
-VM_CPU_COUNT=2
-VM_MEM_SIZE=4096m
+: ${VM_CPU_COUNT:=2}
+: ${VM_MEM_SIZE:=4096m}
 
 EXTRA_DISK_NUM=5
 BHYVE_EXTRA_DISK_PARAM=""
@@ -49,12 +49,6 @@ FBSD_BRANCH_SHORT=`echo ${FBSD_BRANCH} | sed -e 's,.*-,,'`
 TEST_VM_NAME="testvm-${FBSD_BRANCH_SHORT}-${TARGET_ARCH}-${BUILD_NUMBER}"
 
 if [ "${USE_QEMU}" = 1 ]; then
-	#XXX: Workaround for qemu-system-arm hanging at boot with -m 4096m.
-	VM_MEM_SIZE=3072m
-
-	# Experiment to see if it's any faster than 2.
-	VM_CPU_COUNT=1
-
 	# run test VM image with qemu
 	set +e
 	timeout -k 60 ${TIMEOUT_VM} /usr/local/bin/qemu-system-${QEMU_ARCH} \


### PR DESCRIPTION
Make it possible for individual jobs to override VM_CPU_COUNT
and VM_MEM_SIZE, and use it where appropriate.