### PR TITLE
load mac_bsdextended at boot time

### DIFF
--- a/scripts/build/config-head/testvm/append/boot/loader.conf
+++ b/scripts/build/config-head/testvm/append/boot/loader.conf
@@ -1,3 +1,4 @@
 autoboot_delay=1
 net.fibs=3
 net.inet.ip.fw.default_to_accept=1
+mac_bsdextended_load="YES"

--- a/scripts/build/config-head/testvm/append/etc/rc.conf
+++ b/scripts/build/config-head/testvm/append/etc/rc.conf
@@ -3,7 +3,6 @@ kld_list="${kld_list} blake2"		# sys/opencrypto
 kld_list="${kld_list} cryptodev"	# sys/opencrypto
 kld_list="${kld_list} fusefs"		# sys/fs/fusefs
 kld_list="${kld_list} ipsec"		# sys/netipsec
-kld_list="${kld_list} mac_bsdextended"	# sys/mac/bsdextended
 kld_list="${kld_list} mac_portacl"	# sys/mac/portacl
 kld_list="${kld_list} mqueuefs"		# sys/kern/mqueue_test
 kld_list="${kld_list} pfsync"		# sys/netpfil/pf (loads pf)

--- a/scripts/build/config/testvm/append/boot/loader.conf
+++ b/scripts/build/config/testvm/append/boot/loader.conf
@@ -1,3 +1,4 @@
 autoboot_delay=1
 net.fibs=3
 net.inet.ip.fw.default_to_accept=1
+mac_bsdextended_load="YES"

--- a/scripts/build/config/testvm/append/etc/rc.conf
+++ b/scripts/build/config/testvm/append/etc/rc.conf
@@ -3,7 +3,6 @@ kld_list="${kld_list} blake2"		# sys/opencrypto
 kld_list="${kld_list} cryptodev"	# sys/opencrypto
 kld_list="${kld_list} fusefs"		# sys/fs/fusefs
 kld_list="${kld_list} ipsec"		# sys/netipsec
-kld_list="${kld_list} mac_bsdextended"	# sys/mac/bsdextended
 kld_list="${kld_list} mac_portacl"	# sys/mac/portacl
 kld_list="${kld_list} mqueuefs"		# sys/kern/mqueue_test
 kld_list="${kld_list} pfsync"		# sys/netpfil/pf (loads pf)

--- a/scripts/build/config/testvm/append/etc/sysctl.conf
+++ b/scripts/build/config/testvm/append/etc/sysctl.conf
@@ -1,4 +1,5 @@
 kern.cryptodevallowsoft=1
 net.add_addr_allfibs=0
+security.mac.bsdextended.enabled=0
 vfs.aio.enable_unsafe=1
 vfs.usermount=1


### PR DESCRIPTION
mac_bsdextended interferes with the fusefs tests.  To resolve that, we
disable mac_bsdextended via a sysctl, set by /etc/sysctl.conf.  However,
/etc/rc.d/sysctl runs _before_ /etc/rc.d/kld.  So that setting won't
take effect unless mac_bsdextended is loaded by loader.conf, not by
kld_list.

Alternatively, it would be possible to load mac_bsdextended by kld_list
if we disable it in /etc/rc.local instead of /etc/sysctl.conf.