### PR TITLE
riscv64-test: use QEMU's built-in OpenSBI

### DIFF
--- a/jobs/FreeBSD-head-riscv64-test/build.sh
+++ b/jobs/FreeBSD-head-riscv64-test/build.sh
@@ -7,7 +7,7 @@ export QEMU_ARCH="riscv64"
 export QEMU_MACHINE="virt"
 # XXX: Note the virtio-blk-device instead of virtio-blk; kernel doesn't seem to support the latter.
 export QEMU_DEVICES="-device virtio-blk-device,drive=hd0 -device virtio-blk-device,drive=hd1"
-export QEMU_EXTRA_PARAM="-bios /usr/local/share/opensbi/platform/qemu/virt/firmware/fw_jump.elf -kernel kernel"
+export QEMU_EXTRA_PARAM="-bios default -kernel kernel"
 
 # XXX: Eventually panics with SMP.
 export VM_CPU_COUNT=1

--- a/jobs/FreeBSD-head-riscv64-test/pkg-list
+++ b/jobs/FreeBSD-head-riscv64-test/pkg-list
@@ -1,2 +1,1 @@
-opensbi
 qemu-devel


### PR DESCRIPTION
Since version 4.1.0, QEMU has shipped with a copy of OpenSBI as the
default firmware for the RISC-V platform, which can be selected with the
'-bios default' command line option.

Since OpenSBI is still in the early stages of development, breaking
changes to the firmware installation paths will occur, as is the case
for the upcoming v0.7 update. Switch to using the 'default' version of
the firmware for our QEMU tests to avoid being disrupted by these
breakages. This version lags behind the version in ports, but it should
be fine for the purposes of CI.