### PR TITLE
add missing dev to fix CI.. #1181

### DIFF
--- a/jobs/FreeBSD-head-amd64-test_ltp/meta/run.sh
+++ b/jobs/FreeBSD-head-amd64-test_ltp/meta/run.sh
@@ -7,7 +7,7 @@ export PATH
 
 # Enable services needed by tests
 sysrc linux_enable="YES"
-for i in proc sys tmp; do
+for i in proc sys tmp dev; do
 	mkdir -p /compat/linux/$i
 done
 service linux start


### PR DESCRIPTION
per: https://ci.freebsd.org/job/FreeBSD-head-amd64-test_ltp/lastBuild/console

the directory to mount linux compat dev is missing and fails. 