### PR TITLE
Boot riscv64-test with u-boot and loader.efi

### DIFF
--- a/jobs/FreeBSD-head-riscv64-test/build.sh
+++ b/jobs/FreeBSD-head-riscv64-test/build.sh
@@ -7,7 +7,9 @@ export QEMU_ARCH="riscv64"
 export QEMU_MACHINE="virt"
 # XXX: Note the virtio-blk-device instead of virtio-blk; kernel doesn't seem to support the latter.
 export QEMU_DEVICES="-device virtio-blk-device,drive=hd0 -device virtio-blk-device,drive=hd1"
-export QEMU_EXTRA_PARAM="-bios default -kernel kernel"
+OPENSBI=/usr/local/share/opensbi/lp64/generic/firmware/fw_jump.elf
+UBOOT=/usr/local/share/u-boot/u-boot-qemu-riscv64/u-boot.bin
+export QEMU_EXTRA_PARAM="-bios $OPENSBI -kernel $UBOOT"
 
 # XXX: Eventually panics with SMP.
 export VM_CPU_COUNT=1

--- a/jobs/FreeBSD-head-riscv64-test/pkg-list
+++ b/jobs/FreeBSD-head-riscv64-test/pkg-list
@@ -1,2 +1,4 @@
 qemu50
+opensbi
+u-boot-qemu-riscv64
 xmlstarlet

--- a/scripts/build/build-test_image-head.sh
+++ b/scripts/build/build-test_image-head.sh
@@ -149,7 +149,7 @@ case "${TARGET}" in
 			-p freebsd-ufs/rootfs:=ufs.img \
 			-o ${OUTPUT_IMG_NAME}
 		;;
-	mips|riscv)
+	mips)
 		mv ufs.img ${OUTPUT_IMG_NAME}
 		;;
 	powerpc)
@@ -159,6 +159,16 @@ case "${TARGET}" in
 			-p prepboot:=ufs/boot/boot1.elf \
 			-p freebsd:=ufs.img \
 			-p freebsd::1G \
+			-o ${OUTPUT_IMG_NAME}
+		;;
+	riscv)
+		mkdir -p efi/EFI/BOOT
+		cp -f ufs/boot/loader_lua.efi efi/EFI/BOOT/bootriscv64.efi
+		sudo makefs -d 6144 -t msdos -s 50m -Z efi.img efi
+		mkimg -s gpt -f raw \
+			-p efi:=efi.img \
+			-p freebsd-swap/swapfs::1G \
+			-p freebsd-ufs/rootfs:=ufs.img \
 			-o ${OUTPUT_IMG_NAME}
 		;;
 	*)


### PR DESCRIPTION
 - Generate an image with an EFI partition
 - Switch back to version of OpenSBI from ports
 - Set -kernel payload to u-boot, which will find loader.efi

I have not tested this, although this is the usual QEMU incantation I use to boot riscv64.