### PR TITLE
Switch to using a reference repo in git.

### DIFF
--- a/jjb/scm.yaml
+++ b/jjb/scm.yaml
@@ -155,13 +155,9 @@
           branches:
             - origin/main
           basedir: doc
-          clean:
-            before: True
-            after: False
           browser: cgit
           browser-url: https://cgit.freebsd.org/doc/
-          wipe-workspace: False
-          shallow-clone: True
+          reference-repo: '/jenkins/repo/doc.git'
 
 - scm:
     name: FreeBSD-ports-head


### PR DESCRIPTION
Implications:
 * Changelogs should start working properly again
 * Switching back to defaults means git will wipe and reclone
   - But this will happen very fast because of the reference repo.