### PR TITLE
Update post-link.py / set-link.py for git.

### DIFF
--- a/artifact/post-link.py
+++ b/artifact/post-link.py
@@ -7,14 +7,20 @@ import os
 
 x = {}
 x['job_name'] = os.environ['JOB_NAME']
-x['revision'] = os.environ['SVN_REVISION']
+if os.environ.get('GIT_COMMIT', False):
+    x['commit'] = os.environ['GIT_COMMIT']
+else:
+    x['revision'] = os.environ['SVN_REVISION']
 x['branch'] = os.environ['FBSD_BRANCH']
 x['target'] = os.environ['FBSD_TARGET']
 x['target_arch'] = os.environ['FBSD_TARGET_ARCH']
 x['link_type'] = os.environ['LINK_TYPE']
 json_req = json.dumps(x)
 
-connections = http.client.HTTPSConnection('artifact.ci.freebsd.org', 8182)
+if os.environ.get('ARTIFACT_SERVER', False):
+    connections = http.client.HTTPSConnection(os.environ['ARTIFACT_SERVER'], 8182)
+else:
+    connections = http.client.HTTPSConnection('artifact.ci.freebsd.org', 8182)
 
 username = os.environ['ARTIFACT_CRED_USER']
 password = os.environ['ARTIFACT_CRED_PASS']

--- a/artifact/set-link.py
+++ b/artifact/set-link.py
@@ -13,7 +13,10 @@ basedir = '/home/artifact/snapshot'
 
 def set_link(x):
     branch = x['branch']
-    revision = 'r' + str(x['revision'])
+    if 'commit' in x:
+        revision = str(x['commit'])
+    else:
+        revision = 'r' + str(x['revision'])
     target = x['target']
     target_arch = x['target_arch']
     link_type = x['link_type']


### PR DESCRIPTION
* Allow passing GIT_COMMIT instead of SVN_REVISION.
  - Behavior when doing so will no longer prepend an "r" to the value.
* Allow overriding ARTIFACT_SERVER in post-link.py.

Deploy hint: Will need to log into artifact.ci.freebsd.org and update set-link.py, and restart the daemon. This procedure is not correctly documented in the wiki currently.