### PR TITLE
Pass -s -de to buildworld/buildkernel make steps

### DIFF
--- a/scripts/build/build-world-kernel-head.sh
+++ b/scripts/build/build-world-kernel-head.sh
@@ -14,14 +14,14 @@ if [ -n "${CROSS_TOOLCHAIN}" ]; then
 	CROSS_TOOLCHAIN_PARAM=CROSS_TOOLCHAIN=${CROSS_TOOLCHAIN}
 fi
 
-sudo make -j ${JFLAG} -DNO_CLEAN \
+sudo make -s -de -j ${JFLAG} -DNO_CLEAN \
 	buildworld \
 	TARGET=${TARGET} \
 	TARGET_ARCH=${TARGET_ARCH} \
 	${CROSS_TOOLCHAIN_PARAM} \
 	__MAKE_CONF=${MAKECONF} \
 	SRCCONF=${SRCCONF}
-sudo make -j ${JFLAG} -DNO_CLEAN \
+sudo make -s -de -j ${JFLAG} -DNO_CLEAN \
 	buildkernel \
 	TARGET=${TARGET} \
 	TARGET_ARCH=${TARGET_ARCH} \

--- a/scripts/build/build-world-kernel.sh
+++ b/scripts/build/build-world-kernel.sh
@@ -10,13 +10,13 @@ SRCCONF=${SRCCONF:-/dev/null}
 
 cd /usr/src
 
-sudo make -j ${JFLAG} -DNO_CLEAN \
+sudo make -s -de -j ${JFLAG} -DNO_CLEAN \
 	buildworld \
 	TARGET=${TARGET} \
 	TARGET_ARCH=${TARGET_ARCH} \
 	__MAKE_CONF=${MAKECONF} \
 	SRCCONF=${SRCCONF}
-sudo make -j ${JFLAG} -DNO_CLEAN \
+sudo make -s -de -j ${JFLAG} -DNO_CLEAN \
 	buildkernel \
 	TARGET=${TARGET} \
 	TARGET_ARCH=${TARGET_ARCH} \

--- a/scripts/build/build1.sh
+++ b/scripts/build/build1.sh
@@ -55,6 +55,6 @@ set +x
 echo "--------------------------------------------------------------"
 set -x
 
-make -j 4 buildworld __MAKE_CONF=${WORKSPACE}/make.conf
-make -j 4 buildkernel __MAKE_CONF=${WORKSPACE}/make.conf
+make -s -de -j 4 buildworld __MAKE_CONF=${WORKSPACE}/make.conf
+make -s -de -j 4 buildkernel __MAKE_CONF=${WORKSPACE}/make.conf
 

--- a/scripts/build/cross-build.sh
+++ b/scripts/build/cross-build.sh
@@ -72,6 +72,6 @@ echo "--------------------------------------------------------------"
 echo ""
 set -x
 
-make -j 4 CROSS_TOOLCHAIN=${TARGET_ARCH}-gcc buildworld __MAKE_CONF=${WORKSPACE}/make.conf
-make -j 4 CROSS_TOOLCHAIN=${TARGET_ARCH}-gcc buildkernel __MAKE_CONF=${WORKSPACE}/make.conf
+make -s -de -j 4 CROSS_TOOLCHAIN=${TARGET_ARCH}-gcc buildworld __MAKE_CONF=${WORKSPACE}/make.conf
+make -s -de -j 4 CROSS_TOOLCHAIN=${TARGET_ARCH}-gcc buildkernel __MAKE_CONF=${WORKSPACE}/make.conf
 


### PR DESCRIPTION
Printing all the commands results in a 80+ MB logfile and is very rarely
useful. Passing -de should print the failed command but unfortunately
does not work when combined with -jN.
However, I have submitted a patch to fix this problem at
https://reviews.freebsd.org/D29647, so there should be no downsides to
enabling -s once that has been merged.