### PR TITLE
Cope with python 3.8

### DIFF
--- a/scripts/build/build-test_image-head.sh
+++ b/scripts/build/build-test_image-head.sh
@@ -79,8 +79,8 @@ if [ "${TARGET}" = "amd64" -o "${TARGET}" = "i386" ]; then
 		nist-kat	\
 		nmap		\
 		perl5		\
-		py37-dpkt	\
-		py37-scapy	\
+		py38-dpkt	\
+		py38-scapy	\
 		python		\
 		python3		\
 		sudo		\


### PR DESCRIPTION
The ports tree moved to Python 3.8, so we can no longer install py37-
packages. Install the py38- equivalents instead.

Sponsored by:   Rubicon Communications, LLC ("Netgate")