### PR TITLE
Add missing \

### DIFF
--- a/scripts/build/build-test_image-head.sh
+++ b/scripts/build/build-test_image-head.sh
@@ -79,8 +79,8 @@ if [ "${TARGET}" = "amd64" -o "${TARGET}" = "i386" ]; then
 		nist-kat	\
 		nmap		\
 		perl5		\
-		net/py-dpkt
-		net/scapy
+		net/py-dpkt	\
+		net/scapy	\
 		python		\
 		python3		\
 		sudo		\


### PR DESCRIPTION
The previous commit accidentally omitted the backslashes at the end of
the line, causing us to not install all required packages, and the
subsequent (invalid) command to fail.

Sponsored by:	Rubicon Communications, LLC ("Netgate")