### PR TITLE
FreeBSD-doc-main: Add verbosity

### DIFF
--- a/jobs/FreeBSD-doc-main/build.sh
+++ b/jobs/FreeBSD-doc-main/build.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
 cd doc
-make -j 2
+make HUGO_ARGS="--verbose --debug --path-warnings"
 
 echo "GIT_COMMIT=${GIT_COMMIT}" > ${WORKSPACE}/trigger.property


### PR DESCRIPTION
HUGO_ARGS is now supported [1].
https://cgit.freebsd.org/doc/commit/?id=163f29fb33bf5cd8101635f5c7cddfcc04a0d28d

Build with single job to see clearly the build logs.