### PR TITLE
riscv64-test: boot via EFI and u-boot

### DIFF
--- a/jobs/FreeBSD-main-riscv64-test/build.sh
+++ b/jobs/FreeBSD-main-riscv64-test/build.sh
@@ -7,7 +7,9 @@ export QEMU_ARCH="riscv64"
 export QEMU_MACHINE="virt"
 # XXX: Note the virtio-blk-device instead of virtio-blk; kernel doesn't seem to support the latter.
 export QEMU_DEVICES="-device virtio-blk-device,drive=hd0 -device virtio-blk-device,drive=hd1"
-export QEMU_EXTRA_PARAM="-bios default -kernel kernel"
+OPENSBI=/usr/local/share/opensbi/lp64/generic/firmware/fw_jump.elf
+UBOOT=/usr/local/share/u-boot/u-boot-qemu-riscv64/u-boot.bin
+export QEMU_EXTRA_PARAM="-bios ${OPENSBI} -kernel ${UBOOT}"
 
 export USE_TEST_SUBR="
 disable-disks-tests.sh

--- a/jobs/FreeBSD-main-riscv64-test/pkg-list
+++ b/jobs/FreeBSD-main-riscv64-test/pkg-list
@@ -1,2 +1,4 @@
+opensbi
 qemu5-nox11
+u-boot-qemu-riscv64
 xmlstarlet

--- a/jobs/FreeBSD-stable-13-riscv64-test/build.sh
+++ b/jobs/FreeBSD-stable-13-riscv64-test/build.sh
@@ -7,7 +7,9 @@ export QEMU_ARCH="riscv64"
 export QEMU_MACHINE="virt"
 # XXX: Note the virtio-blk-device instead of virtio-blk; kernel doesn't seem to support the latter.
 export QEMU_DEVICES="-device virtio-blk-device,drive=hd0 -device virtio-blk-device,drive=hd1"
-export QEMU_EXTRA_PARAM="-bios default -kernel kernel"
+OPENSBI=/usr/local/share/opensbi/lp64/generic/firmware/fw_jump.elf
+UBOOT=/usr/local/share/u-boot/u-boot-qemu-riscv64/u-boot.bin
+export QEMU_EXTRA_PARAM="-bios ${OPENSBI} -kernel ${UBOOT}"
 
 export USE_TEST_SUBR="
 disable-disks-tests.sh

--- a/jobs/FreeBSD-stable-13-riscv64-test/pkg-list
+++ b/jobs/FreeBSD-stable-13-riscv64-test/pkg-list
@@ -1,2 +1,4 @@
+opensbi
 qemu5-nox11
+u-boot-qemu-riscv64
 xmlstarlet

--- a/scripts/build/build-test_image-13.sh
+++ b/scripts/build/build-test_image-13.sh
@@ -159,7 +159,7 @@ case "${TARGET}" in
 			-p freebsd-ufs/rootfs:=ufs.img \
 			-o ${OUTPUT_IMG_NAME}
 		;;
-	mips|riscv)
+	mips)
 		mv ufs.img ${OUTPUT_IMG_NAME}
 		;;
 	powerpc)
@@ -169,6 +169,16 @@ case "${TARGET}" in
 			-p prepboot:=ufs/boot/boot1.elf \
 			-p freebsd:=ufs.img \
 			-p freebsd::1G \
+			-o ${OUTPUT_IMG_NAME}
+		;;
+	riscv)
+		mkdir -p efi/EFI/BOOT
+		cp -f ufs/boot/loader_lua.efi efi/EFI/BOOT/bootriscv64.efi
+		sudo makefs -d 6144 -t msdos -s 50m -Z efi.img efi
+		mkimg -s gpt -f raw \
+			-p efi:=efi.img \
+			-p freebsd-swap/swapfs::1G \
+			-p freebsd-ufs/rootfs:=ufs.img \
 			-o ${OUTPUT_IMG_NAME}
 		;;
 	*)

--- a/scripts/build/build-test_image-head.sh
+++ b/scripts/build/build-test_image-head.sh
@@ -159,7 +159,7 @@ case "${TARGET}" in
 			-p freebsd-ufs/rootfs:=ufs.img \
 			-o ${OUTPUT_IMG_NAME}
 		;;
-	mips|riscv)
+	mips)
 		mv ufs.img ${OUTPUT_IMG_NAME}
 		;;
 	powerpc)
@@ -169,6 +169,16 @@ case "${TARGET}" in
 			-p prepboot:=ufs/boot/boot1.elf \
 			-p freebsd:=ufs.img \
 			-p freebsd::1G \
+			-o ${OUTPUT_IMG_NAME}
+		;;
+	riscv)
+		mkdir -p efi/EFI/BOOT
+		cp -f ufs/boot/loader_lua.efi efi/EFI/BOOT/bootriscv64.efi
+		sudo makefs -d 6144 -t msdos -s 50m -Z efi.img efi
+		mkimg -s gpt -f raw \
+			-p efi:=efi.img \
+			-p freebsd-swap/swapfs::1G \
+			-p freebsd-ufs/rootfs:=ufs.img \
 			-o ${OUTPUT_IMG_NAME}
 		;;
 	*)


### PR DESCRIPTION
This re-applies 8cc25cc14bbc for stable/13 and main, making the QEMU
test setup similar to other architectures like arm64 and arm. We
assemble a complete disk image with loader.efi installed to the ESP,
which u-boot will detect and load.