### PR TITLE
FreeBSD-doc-main*: Adjust requirements

### DIFF
--- a/jobs/FreeBSD-doc-main-offline_docs/pkg-list
+++ b/jobs/FreeBSD-doc-main-offline_docs/pkg-list
@@ -1,4 +1,2 @@
 docproj
-python3
-rubygem-asciidoctor-pdf
 rubygem-asciidoctor-epub3

--- a/jobs/FreeBSD-doc-main/pkg-list
+++ b/jobs/FreeBSD-doc-main/pkg-list
@@ -1,3 +1,1 @@
 docproj
-python3
-rubygem-asciidoctor-pdf


### PR DESCRIPTION
- Python is not necessary anymore for building the website and
  documentation projects.

- rubygem-asciidoctor-pdf is already present in the docproj metaport.