### PR TITLE
FreeBSD-doc-main: Adjust hugo command flags

### DIFF
--- a/jobs/FreeBSD-doc-main/build.sh
+++ b/jobs/FreeBSD-doc-main/build.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
 cd doc
-make HUGO_ARGS="--verbose --debug --path-warnings"
+make HUGO_ARGS="--verbose --debug --printPathWarnings"
 
 echo "USE_GIT_COMMIT=${GIT_COMMIT}" > ${WORKSPACE}/trigger.property


### PR DESCRIPTION
https://github.com/gohugoio/hugo/releases/tag/v0.93.0
 ...
 We have renamed some command line flags for consistency: --i18n-warnings
 to printI18nWarnings, --path-warnings, --print-men to
 --printPathWarnings, --printMemoryUsage.