### PR TITLE
test image: UFS partition on powerpc64le should be in LE

### DIFF
--- a/scripts/build/build-test_image-13.sh
+++ b/scripts/build/build-test_image-13.sh
@@ -127,8 +127,8 @@ fdesc           /dev/fd         fdescfs rw      0       0
 EOF
 fi
 
-case "${TARGET}" in
-	mips|powerpc)
+case "${TARGET_ARCH}" in
+	mips|mips64|powerpc|powerpcspe|powerpc64)
 		B_FLAG="big"
 		;;
 	*)


### PR DESCRIPTION
Sponsored by:   Instituto de Pesquisas Eldorado (eldorado.org.br)