### PR TITLE
Add pytest to VM HEAD builds.

### DIFF
--- a/scripts/build/build-test_image-head.sh
+++ b/scripts/build/build-test_image-head.sh
@@ -78,6 +78,7 @@ if [ "${TARGET}" = "amd64" -o "${TARGET}" = "i386" ]; then
 	# pkgconf: local/lutok/examples_test, local/atf/atf-c, local/atf/atf-c++
 	# py-dpkt: sys/opencrypto/runtests
 	# python3: sys/opencrypto/runtests
+	# pytest38: sys/net/routing, tests in python in general
 	# sudo: tests/sys/cddl/zfs/tests/delegate/...
 	# tcptestsuite: network stack test suite
 	sudo chroot ufs pkg install -y	\
@@ -92,6 +93,7 @@ if [ "${TARGET}" = "amd64" -o "${TARGET}" = "i386" ]; then
 		net/scapy	\
 		python		\
 		python3		\
+		py38-pytest	\
 		sudo		\
 		tcptestsuite
 


### PR DESCRIPTION
pytest-atf integration was added to FreeBSD base in [8eb2bee6c0f](https://cgit.freebsd.org/src/commit/?id=8eb2bee6c0f4957c6c1cea826e59cda4d18a2a64). This change allows to actually run pytest-powered tests.