### PR TITLE
powerpc 32 bit disk image job improvements

### DIFF
--- a/jobs/FreeBSD-main-powerpc-images/build.sh
+++ b/jobs/FreeBSD-main-powerpc-images/build.sh
@@ -25,10 +25,11 @@ do
 	sudo tar Jxf ${f}.txz -C ufs
 done
 
+# TODO partition label isn't working with APM scheme, using device name instead
 cat <<EOF | sudo tee ufs/etc/fstab
 # Device        Mountpoint      FStype  Options Dump    Pass#
-/dev/ufs/swapfs none            swap    sw      0       0
-/dev/ufs/rootfs /               ufs     rw      1       1
+/dev/vtbd0s4 none            swap    sw      0       0
+/dev/vtbd0s3 /               ufs     rw      1       1
 EOF
 
 sudo dd if=/dev/random of=ufs/boot/entropy bs=4k count=1

--- a/jobs/FreeBSD-main-powerpcspe-images/build.sh
+++ b/jobs/FreeBSD-main-powerpcspe-images/build.sh
@@ -27,16 +27,16 @@ done
 
 cat <<EOF | sudo tee ufs/etc/fstab
 # Device        Mountpoint      FStype  Options Dump    Pass#
-/dev/vtbd0p1	none            swap    sw      0       0
-/dev/vtbd0p2	/               ufs     rw      1       1
+/dev/gpt/swapfs	none            swap    sw      0       0
+/dev/gpt/rootfs	/               ufs     rw      1       1
 EOF
 
 sudo dd if=/dev/random of=ufs/boot/entropy bs=4k count=1
 sudo makefs -B be -d 6144 -t ffs -s 16g -o version=2,bsize=32768,fsize=4096,density=16384 ufs.img ufs
 
 mkimg -a 1 -s gpt -f qcow2 \
-	-p freebsd-ufs:=ufs.img \
-	-p freebsd-swap::1G \
+	-p freebsd-ufs/rootfs:=ufs.img \
+	-p freebsd-swap/swapfs::1G \
 	-o disk.qcow2
 zstd --rm disk.qcow2
 


### PR DESCRIPTION
- remove labels from powerpc, it doesn't work with APM disk layout but GPT. The reason is unknown.
- use labels on powerpcspe, it works after src commit 8b57548e9a38ffbb122947043bafabb92b037fb3
