### PR TITLE
riscv64-test: add workaround for long ISA string

### DIFF
--- a/jobs/FreeBSD-main-riscv64-test/build.sh
+++ b/jobs/FreeBSD-main-riscv64-test/build.sh
@@ -9,7 +9,7 @@ export QEMU_MACHINE="virt"
 export QEMU_DEVICES="-device virtio-blk-device,drive=hd0 -device virtio-blk-device,drive=hd1"
 OPENSBI=/usr/local/share/opensbi/lp64/generic/firmware/fw_jump.elf
 UBOOT=/usr/local/share/u-boot/u-boot-qemu-riscv64/u-boot.bin
-export QEMU_EXTRA_PARAM="-bios ${OPENSBI} -kernel ${UBOOT}"
+export QEMU_EXTRA_PARAM="-cpu rv64,short-isa-string=on -bios ${OPENSBI} -kernel ${UBOOT}"
 
 export USE_TEST_SUBR="
 disable-disks-tests.sh

--- a/jobs/FreeBSD-stable-13-riscv64-test/build.sh
+++ b/jobs/FreeBSD-stable-13-riscv64-test/build.sh
@@ -9,7 +9,7 @@ export QEMU_MACHINE="virt"
 export QEMU_DEVICES="-device virtio-blk-device,drive=hd0 -device virtio-blk-device,drive=hd1"
 OPENSBI=/usr/local/share/opensbi/lp64/generic/firmware/fw_jump.elf
 UBOOT=/usr/local/share/u-boot/u-boot-qemu-riscv64/u-boot.bin
-export QEMU_EXTRA_PARAM="-bios ${OPENSBI} -kernel ${UBOOT}"
+export QEMU_EXTRA_PARAM="-cpu rv64,short-isa-string=on -bios ${OPENSBI} -kernel ${UBOOT}"
 
 export USE_TEST_SUBR="
 disable-disks-tests.sh


### PR DESCRIPTION
The CPU ISA string provided by default in QEMU 7.2 triggers an assertion in the kernel. Until this is fixed, tell QEMU to generate the short ISA string like it did in previous versions. This is to restore the riscv64-test jobs.

Tested locally by executing CI's QEMU commandline exactly, before and after the addition.