### PR TITLE
powerpc64-images: fix artifact file names

### DIFF
--- a/jobs/FreeBSD-main-powerpc64-images/build.sh
+++ b/jobs/FreeBSD-main-powerpc64-images/build.sh
@@ -53,4 +53,5 @@ zstd --rm disk-apple.qcow2
 cd ${WORKSPACE}
 rm -fr artifact
 mkdir -p artifact/${ARTIFACT_SUBDIR}
-mv work/disk.qcow2.zst artifact/${ARTIFACT_SUBDIR}
+mv work/disk-pseries.qcow2.zst artifact/${ARTIFACT_SUBDIR}
+mv work/disk-apple.qcow2.zst artifact/${ARTIFACT_SUBDIR}


### PR DESCRIPTION
Fix artifact file names after 519eaee6c7a6a5267d1dded673c1c1f280cec8a5