### PR TITLE
Use QEMU with '-smp 1' when running powerpc64 tests

### DIFF
--- a/jobs/FreeBSD-main-powerpc64-test/build.sh
+++ b/jobs/FreeBSD-main-powerpc64-test/build.sh
@@ -11,6 +11,8 @@ export QEMU_MACHINE="pseries,cap-hpt-max-page-size=16M"
 export QEMU_DEVICES="-device virtio-blk,drive=hd1 -device virtio-blk,drive=hd0"
 # The -accel tcg,thread=multi is supposed to improve performance.
 export QEMU_EXTRA_PARAM="-vga none -accel tcg,thread=multi"
+# powerpc64 VM often hangs after "Launching APs" with SMP >1 in TCG mode
+export VM_CPU_COUNT="1"
 
 export USE_TEST_SUBR="
 disable-disks-tests.sh

--- a/jobs/FreeBSD-main-powerpc64le-test/build.sh
+++ b/jobs/FreeBSD-main-powerpc64le-test/build.sh
@@ -11,6 +11,8 @@ export QEMU_MACHINE="pseries,cap-hpt-max-page-size=16M"
 export QEMU_DEVICES="-device virtio-blk,drive=hd1 -device virtio-blk,drive=hd0"
 # The -accel tcg,thread=multi is supposed to improve performance.
 export QEMU_EXTRA_PARAM="-vga none -accel tcg,thread=multi"
+# powerpc64 VM often hangs after "Launching APs" with SMP >1 in TCG mode
+export VM_CPU_COUNT="1"
 
 export USE_TEST_SUBR="
 disable-disks-tests.sh

--- a/jobs/FreeBSD-stable-13-powerpc64-test/build.sh
+++ b/jobs/FreeBSD-stable-13-powerpc64-test/build.sh
@@ -11,6 +11,8 @@ export QEMU_MACHINE="pseries,cap-hpt-max-page-size=16M"
 export QEMU_DEVICES="-device virtio-blk,drive=hd1 -device virtio-blk,drive=hd0"
 # The -accel tcg,thread=multi is supposed to improve performance.
 export QEMU_EXTRA_PARAM="-vga none -accel tcg,thread=multi"
+# powerpc64 VM often hangs after "Launching APs" with SMP >1 in TCG mode
+export VM_CPU_COUNT="1"
 
 export USE_TEST_SUBR="
 disable-disks-tests.sh

--- a/jobs/FreeBSD-stable-13-powerpc64le-test/build.sh
+++ b/jobs/FreeBSD-stable-13-powerpc64le-test/build.sh
@@ -11,6 +11,8 @@ export QEMU_MACHINE="pseries,cap-hpt-max-page-size=16M"
 export QEMU_DEVICES="-device virtio-blk,drive=hd1 -device virtio-blk,drive=hd0"
 # The -accel tcg,thread=multi is supposed to improve performance.
 export QEMU_EXTRA_PARAM="-vga none -accel tcg,thread=multi"
+# powerpc64 VM often hangs after "Launching APs" with SMP >1 in TCG mode
+export VM_CPU_COUNT="1"
 
 export USE_TEST_SUBR="
 disable-disks-tests.sh


### PR DESCRIPTION
scripts/test/run-tests.sh calls QEMU with "-smp 2" by default, but powerpc64 VMs often hangs during boot after "Launching AP" when QEMU is in TCG mode. Since the reason is unknown, set SMP to "1" as it proved stable on my local tests.