### PR TITLE
Install security/openvpn in test images

### DIFF
--- a/scripts/build/build-test_image-head.sh
+++ b/scripts/build/build-test_image-head.sh
@@ -94,6 +94,7 @@ if [ "${TARGET}" = "amd64" -o "${TARGET}" = "i386" ]; then
 		python		\
 		python3		\
 		devel/py-pytest	\
+		security/openvpn \
 		sudo		\
 		tcptestsuite
 


### PR DESCRIPTION
This enables the if_ovpn tests to be run.

Sponsored by:   Rubicon Communications, LLC ("Netgate")