### PR TITLE
Load if_ovpn.ko before running tests on main

### DIFF
--- a/scripts/build/config-head/testvm/append/etc/rc.conf
+++ b/scripts/build/config-head/testvm/append/etc/rc.conf
@@ -14,6 +14,7 @@ kld_list="${kld_list} ipdivert"		# sys/netinet (loads ipdivert)
 kld_list="${kld_list} dummynet"		# sys/netpfil/common
 kld_list="${kld_list} carp"		# sys/netinet/carp
 kld_list="${kld_list} if_stf"		# sys/net/if_stf
+kld_list="${kld_list} if_ovpn"		# sys/net/if_ovpn
 auditd_enable="YES"
 background_fsck="NO"
 sendmail_enable="NONE"


### PR DESCRIPTION
Otherwise the if_ovpn tests are skipped.