### PR TITLE
Revert "riscv64-test: add workaround for long ISA string"

### DIFF
--- a/jobs/FreeBSD-main-riscv64-test/build.sh
+++ b/jobs/FreeBSD-main-riscv64-test/build.sh
@@ -9,7 +9,7 @@ export QEMU_MACHINE="virt"
 export QEMU_DEVICES="-device virtio-blk-device,drive=hd0 -device virtio-blk-device,drive=hd1"
 OPENSBI=/usr/local/share/opensbi/lp64/generic/firmware/fw_jump.elf
 UBOOT=/usr/local/share/u-boot/u-boot-qemu-riscv64/u-boot.bin
-export QEMU_EXTRA_PARAM="-cpu rv64,short-isa-string=on -bios ${OPENSBI} -kernel ${UBOOT}"
+export QEMU_EXTRA_PARAM="-bios ${OPENSBI} -kernel ${UBOOT}"
 
 export USE_TEST_SUBR="
 disable-disks-tests.sh

--- a/jobs/FreeBSD-stable-13-riscv64-test/build.sh
+++ b/jobs/FreeBSD-stable-13-riscv64-test/build.sh
@@ -9,7 +9,7 @@ export QEMU_MACHINE="virt"
 export QEMU_DEVICES="-device virtio-blk-device,drive=hd0 -device virtio-blk-device,drive=hd1"
 OPENSBI=/usr/local/share/opensbi/lp64/generic/firmware/fw_jump.elf
 UBOOT=/usr/local/share/u-boot/u-boot-qemu-riscv64/u-boot.bin
-export QEMU_EXTRA_PARAM="-cpu rv64,short-isa-string=on -bios ${OPENSBI} -kernel ${UBOOT}"
+export QEMU_EXTRA_PARAM="-bios ${OPENSBI} -kernel ${UBOOT}"
 
 export USE_TEST_SUBR="
 disable-disks-tests.sh


### PR DESCRIPTION
The underlying issue has been fixed in both main and stable/13, so the workaround is no longer required.

This reverts commit c88044089df5d917699ed00fcae122dcd92272c7.