### PR TITLE
fix branch name for 14/STABLE disk image build jobs

### DIFF
--- a/jobs/FreeBSD-stable-14-aarch64-images/build.sh
+++ b/jobs/FreeBSD-stable-14-aarch64-images/build.sh
@@ -7,7 +7,7 @@ if [ -z "${GIT_COMMIT}" ]; then
 	exit 1
 fi
 
-BRANCH=main
+BRANCH=stable-14
 TARGET=arm64
 TARGET_ARCH=aarch64
 

--- a/jobs/FreeBSD-stable-14-amd64-images/build.sh
+++ b/jobs/FreeBSD-stable-14-amd64-images/build.sh
@@ -7,7 +7,7 @@ if [ -z "${GIT_COMMIT}" ]; then
 	exit 1
 fi
 
-BRANCH=main
+BRANCH=stable-14
 TARGET=amd64
 TARGET_ARCH=amd64
 

--- a/jobs/FreeBSD-stable-14-i386-images/build.sh
+++ b/jobs/FreeBSD-stable-14-i386-images/build.sh
@@ -7,7 +7,7 @@ if [ -z "${GIT_COMMIT}" ]; then
 	exit 1
 fi
 
-BRANCH=main
+BRANCH=stable-14
 TARGET=i386
 TARGET_ARCH=i386
 

--- a/jobs/FreeBSD-stable-14-powerpc-images/build.sh
+++ b/jobs/FreeBSD-stable-14-powerpc-images/build.sh
@@ -7,7 +7,7 @@ if [ -z "${GIT_COMMIT}" ]; then
 	exit 1
 fi
 
-BRANCH=main
+BRANCH=stable-14
 TARGET=powerpc
 TARGET_ARCH=powerpc
 

--- a/jobs/FreeBSD-stable-14-powerpc64-images/build.sh
+++ b/jobs/FreeBSD-stable-14-powerpc64-images/build.sh
@@ -7,7 +7,7 @@ if [ -z "${GIT_COMMIT}" ]; then
 	exit 1
 fi
 
-BRANCH=main
+BRANCH=stable-14
 TARGET=powerpc
 TARGET_ARCH=powerpc64
 

--- a/jobs/FreeBSD-stable-14-powerpc64le-images/build.sh
+++ b/jobs/FreeBSD-stable-14-powerpc64le-images/build.sh
@@ -7,7 +7,7 @@ if [ -z "${GIT_COMMIT}" ]; then
 	exit 1
 fi
 
-BRANCH=main
+BRANCH=stable-14
 TARGET=powerpc
 TARGET_ARCH=powerpc64le
 

--- a/jobs/FreeBSD-stable-14-powerpcspe-images/build.sh
+++ b/jobs/FreeBSD-stable-14-powerpcspe-images/build.sh
@@ -7,7 +7,7 @@ if [ -z "${GIT_COMMIT}" ]; then
 	exit 1
 fi
 
-BRANCH=main
+BRANCH=stable-14
 TARGET=powerpc
 TARGET_ARCH=powerpcspe
 


### PR DESCRIPTION
The new image build jobs for STABLE/14 are still pointing to main branch. Let's change it to stable-14 as expected