### PR TITLE
Increase the timeout for amd64 test jobs

### DIFF
--- a/jjb/template.yaml
+++ b/jjb/template.yaml
@@ -228,7 +228,7 @@
     wrappers:
       - timestamps
       - timeout:
-          timeout: 240
+          timeout: 360
           timeout-var: 'BUILD_TIMEOUT'
           fail: true
           type: absolute


### PR DESCRIPTION
I think this is the right timeout to bump but am not sure.