### PR TITLE
Install sysutils/porch in the test image

### DIFF
--- a/scripts/build/build-test_image-13.sh
+++ b/scripts/build/build-test_image-13.sh
@@ -76,6 +76,7 @@ if [ "${TARGET}" = "amd64" -o "${TARGET}" = "i386" ]; then
 	# nmap: sys/netinet/fibs_test:arpresolve_checks_interface_fib
 	# perl5: lots of stuff
 	# pkgconf: local/lutok/examples_test, local/atf/atf-c, local/atf/atf-c++
+	# porch: sys/kern/tty
 	# py-dpkt: sys/opencrypto/runtests
 	# python3: sys/opencrypto/runtests
 	# sudo: tests/sys/cddl/zfs/tests/delegate/...
@@ -88,6 +89,7 @@ if [ "${TARGET}" = "amd64" -o "${TARGET}" = "i386" ]; then
 		nist-kat	\
 		nmap		\
 		perl5		\
+		porch		\
 		net/py-dpkt	\
 		net/scapy	\
 		python		\

--- a/scripts/build/build-test_image-head.sh
+++ b/scripts/build/build-test_image-head.sh
@@ -77,6 +77,7 @@ if [ "${TARGET}" = "amd64" -o "${TARGET}" = "i386" ]; then
 	# nmap: sys/netinet/fibs_test:arpresolve_checks_interface_fib
 	# perl5: lots of stuff
 	# pkgconf: local/lutok/examples_test, local/atf/atf-c, local/atf/atf-c++
+	# porch: sys/kern/tty
 	# py-dpkt: sys/opencrypto/runtests
 	# python3: sys/opencrypto/runtests
 	# devel/py-pytest: sys/net/routing, tests in python in general
@@ -91,6 +92,7 @@ if [ "${TARGET}" = "amd64" -o "${TARGET}" = "i386" ]; then
 		nist-kat	\
 		nmap		\
 		perl5		\
+		porch		\
 		net/py-dpkt	\
 		net/scapy	\
 		python		\


### PR DESCRIPTION
As of FreeBSD commit
096c39fae4a ("tests: kern: add some porch(1)-based tty tests"), we have some tty tests that will run if porch is installed.  Add it to the test image now.

The commit in question hasn't yet been MFC'd to stable/13 and thus, the test image for 13 does not *currently* need porch, but it's a pretty light package and I do anticipate MFC'ing the tests in that direction.