### PR TITLE
[Freebsd-doc-main]: Fix build

### DIFF
--- a/jobs/FreeBSD-doc-main/build.sh
+++ b/jobs/FreeBSD-doc-main/build.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
 cd doc
-make HUGO_ARGS="--verbose --debug --printPathWarnings"
+make HUGO_ARGS="--logLevel debug --printPathWarnings"
 
 echo "USE_GIT_COMMIT=${GIT_COMMIT}" > ${WORKSPACE}/trigger.property


### PR DESCRIPTION
@lwhsu 

`--verbose` has been deprecated and removed.

Use `--logLevel` instead.