### PR TITLE
Workaround fetching wrong test image

### DIFF
--- a/scripts/test/run-tests.sh
+++ b/scripts/test/run-tests.sh
@@ -7,9 +7,16 @@ if [ -z "${GIT_COMMIT}" ]; then
 	exit 1
 fi
 
+_GIT_COMMIT="${GIT_COMMIT}"
+
+if [ ! -z "${USE_GIT_COMMIT}" -a "${USE_GIT_COMMIT}" != "${GIT_COMMIT}" ]; then
+	echo "GIT_COMMIT ${GIT_COMMIT} does not match USE_GIT_COMMIT ${USE_GIT_COMMIT}, use USE_GIT_COMMIT for test"
+	_GIT_COMMIT="${USE_GIT_COMMIT}"
+fi
+
 KERNCONF=${KERNCONF:-GENERIC}
 ARTIFACT_SERVER=${ARTIFACT_SERVER:-artifact.ci.freebsd.org}
-ARTIFACT_SUBDIR=snapshot/${FBSD_BRANCH}/${GIT_COMMIT}/${TARGET}/${TARGET_ARCH}
+ARTIFACT_SUBDIR=snapshot/${FBSD_BRANCH}/${_GIT_COMMIT}/${TARGET}/${TARGET_ARCH}
 if [ "${KERNCONF}" = "GENERIC" ]; then
 	IMG_NAME=disk-test.img
 else


### PR DESCRIPTION
For some unclear reason the GIT_COMMIT environment is overwritten and is identical with GIT_PREVIOUS_COMMIT which is not what we want. Actually it should be the same with USE_GIT_COMMIT when it exists.