### PR TITLE
build-world-kernel-head.sh: switch to src tree's tests/ci Makefile

### DIFF
--- a/scripts/build/build-world-kernel-head.sh
+++ b/scripts/build/build-world-kernel-head.sh
@@ -2,44 +2,37 @@
 
 set -ex
 
-export MAKEOBJDIRPREFIX=${WORKSPACE}/obj
+MAKEOBJDIRPREFIX=${WORKSPACE}/obj
 rm -fr ${MAKEOBJDIRPREFIX}
+
 
 MAKECONF=${MAKECONF:-/dev/null}
 SRCCONF=${SRCCONF:-/dev/null}
-
-cd /usr/src
 
 if [ -n "${CROSS_TOOLCHAIN}" ]; then
 	CROSS_TOOLCHAIN_PARAM=CROSS_TOOLCHAIN=${CROSS_TOOLCHAIN}
 fi
 
-sudo make -j ${JFLAG} -DWITHOUT_CLEAN \
-	buildworld \
+OUTPUT_IMG=${WORKSPACE}/disk-test.img
+sudo env MAKEOBJDIRPREFIX=${MAKEOBJDIRPREFIX} make \
+	-C /usr/src/tests/ci \
+	ci-buildimage-${TARGET_ARCH} \
 	TARGET=${TARGET} \
 	TARGET_ARCH=${TARGET_ARCH} \
 	${CROSS_TOOLCHAIN_PARAM} \
 	__MAKE_CONF=${MAKECONF} \
-	SRCCONF=${SRCCONF}
-sudo make -j ${JFLAG} -DWITHOUT_CLEAN \
-	buildkernel \
-	TARGET=${TARGET} \
-	TARGET_ARCH=${TARGET_ARCH} \
-	${CROSS_TOOLCHAIN_PARAM} \
-	__MAKE_CONF=${MAKECONF} \
-	SRCCONF=${SRCCONF}
-
-cd /usr/src/release
-
-sudo make clean
-sudo make -DNOPORTS -DNOSRC -DNODOC packagesystem \
-	TARGET=${TARGET} TARGET_ARCH=${TARGET_ARCH} \
-	MAKE="make -DDB_FROM_SRC __MAKE_CONF=${MAKECONF} SRCCONF=${SRCCONF}"
+	MAKECONF=${MAKECONF} \
+	SRCCONF=${SRCCONF} \
+	SRC_ENV_CONF=/dev/null \
+	METAMODE= \
+	CITYPE=full \
+	CIENV=jenkins \
+	CIDISK=${OUTPUT_IMG} \
+	PARALLEL_JOBS=${JFLAG}
 
 ARTIFACT_DEST=artifact/${FBSD_BRANCH}/${GIT_COMMIT}/${TARGET}/${TARGET_ARCH}
 sudo mkdir -p ${ARTIFACT_DEST}
-sudo mv /usr/obj/usr/src/${TARGET}.${TARGET_ARCH}/release/*.txz ${ARTIFACT_DEST}
-sudo mv /usr/obj/usr/src/${TARGET}.${TARGET_ARCH}/release/MANIFEST ${ARTIFACT_DEST}
+sudo mv ${OUTPUT_IMG} ${ARTIFACT_DEST}
 
 echo "${GIT_COMMIT}" | sudo tee ${ARTIFACT_DEST}/revision.txt
 


### PR DESCRIPTION
This removes the need for FreeBSD-*-testvm jenkins jobs since it also handles building a working disk image.