### PR TITLE
fix: correct spelling typos in scripts and docs

### DIFF
--- a/jjb/README.md
+++ b/jjb/README.md
@@ -3,7 +3,7 @@
 Setup:
 - Install jenkins job builder from source (recommended) or ports/pkg `devel/py-jenkins-job-builder`
 - `cp jenkins_jobs.ini.sample jenkins_jobs.ini`
-- Edit `jenkins_jobs.ini` for your credenticals of ci.FreeBSD.org
+- Edit `jenkins_jobs.ini` for your credentials of ci.FreeBSD.org
   (https://ci.freebsd.org/me/configure -> "show api token")
 
 Update jenkins jobs:

--- a/salt/usr/local/etc/salt/states/orch/README.md
+++ b/salt/usr/local/etc/salt/states/orch/README.md
@@ -1,4 +1,4 @@
-# FreeBSD CI Salt Orachestration
+# FreeBSD CI Salt Orchestration
 
 This directory is for salt based orchestration for freebsd ci system
 

--- a/scripts/java/run-jtreg.sh
+++ b/scripts/java/run-jtreg.sh
@@ -48,7 +48,7 @@ usage()
 	echo "	-k				: cleanup and unmount poudriere jail if it is currently mounted, useful alongside the"
 	echo "					  -n switch, to keep jails mounted for debugging between runs while still starting"
 	echo "					  with a fresh start."
-	echo "	-t <tests>		: run a subset of test projects.  Argument is a comma seperated list of test projects."
+	echo "	-t <tests>		: run a subset of test projects.  Argument is a comma separated list of test projects."
 	echo "					  available projects are nashorn, langtools, hotspot, and jdk"
 	echo "					  defaults to running all test projects"
 	echo "Example: $0 -v releng/10.1 -a amd64 -p openjdk8"


### PR DESCRIPTION
Fix three spelling typos found across the repo:

- scripts/java/run-jtreg.sh: "seperated" → "separated"
- jjb/README.md: "credenticals" → "credentials"
- salt/usr/local/etc/salt/states/orch/README.md: "Orachestration" → "Orchestration"